### PR TITLE
Bump Rust toolchain version

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -3,7 +3,6 @@ FROM ubuntu:16.04
 ENV ROCKSDB_LIB_DIR=/usr/lib \
   SNAPPY_LIB_DIR=/usr/lib/x86_64-linux-gnu \
   CARGO_TARGET_DIR=/target
-ARG RUST_VERSION=1.34.0
 
 RUN apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -31,6 +30,8 @@ RUN apt-get update && \
     librocksdb5.17 \
     protobuf-compiler \
     clang-8
+
+ARG RUST_VERSION=1.36.0
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VERSION && \
   ln -s $HOME/.cargo/bin/* /usr/bin && \
   mkdir -p /cargo/git && \

--- a/dev/README.md
+++ b/dev/README.md
@@ -3,7 +3,8 @@
 This Docker image, `slowli/exonum-env`, allows to quickly deploy or test Exonum apps.
 The image does not contain Exonum itself (it's a library), but rather dependencies
 necessary to build a reasonable majority of Exonum apps, such as Rust, RocksDB, libsodium
-and Protobuf.
+and Protobuf. The image is based on Ubuntu 16.04 Xenial. It contains one of the latest
+stable Rust toolchains. Docker tags for the image are based on the packaged Rust toolchain.
 
 Because of large size, this image is more fitting for use as a building container
 (e.g., in [multistage builds][docker-multistage]) than as a final image for an Exonum app.


### PR DESCRIPTION
This PR bumps Rust version to 1.36.0 for the `exonum-env` image.